### PR TITLE
Replace `--whitelist` with `--allowlist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A CLI tool to test web accessibility on multiple web pages based on a list of UR
   - [Configure](#configure)
   - [Run the scan](#run-the-scan)
   - [Create a summarized report](#create-a-summarized-report)
-  - [Define whitelist](#define-whitelist)
+  - [Define allowlist](#define-allowlist)
 - [Configuring axe-scan](#configuring-axe-scan)
   - [`axeCoreTags`](#axecoretags)
     - [`Default value`](#default-value)
@@ -47,7 +47,7 @@ Looking a little deeper into the actual contents of the WCAG, however, you will 
 - **Uses axe-core.** The open-sourced accessibility testing engine [axe-core](https://github.com/dequelabs/axe-core) provided by Deque Systems, Inc. is one of the leading testing engines in the world. Tools using this engine to assist every step of web development are abundant and mostly free of charge. Such testing results will be consistent with axe-scan as long as they use axe-core. This common use of axe-core can be time-saving for both the developer and the client; developers can stop worrying about making last-minute changes in web design.
 - **Test multiple web pages at once.** There are plenty of browser extensions and other accessibility testing tools in the world, but (surprisingly) not many can test multiple pages at once. In axe-scan, you only have to prepare a text file with the list of URLs to conduct the test.
 - **Output results as CSV.** Testing results can be easily saved as a CSV file and shared with your team using a spreadsheet application to discuss the items requiring action.
-- **Whitelist the subset of results for repetitive testing.** Some results of axe-core are labeled `incomplete`, which refers to HTML elements that axe-core could not mechanically determine as `passes` or `violations` of the rules. These `incomplete` results may include elements that do not need further action. To avoid such elements from repetitively appearing in the results, the axe-scan provides an option to whitelist the elements.
+- **Allowlist for repetitive testing.** Some results of axe-core are labeled `incomplete`, which refers to HTML elements that axe-core could not mechanically determine as `passes` or `violations` of the rules. These `incomplete` results may include elements that do not need further action. To avoid such elements from repetitively appearing in the results, the axe-scan provides an option to define the list of the elements as an allowlist, .
 - **Localizations available in axe-core are reflected in the output.** axe-core comes with the community-maintained set of localizations ([Supported Locales | axe-core](https://github.com/dequelabs/axe-core#supported-locales)). You can easily change the language of the axe-scan results to any of the localizations supported in axe-core.
 - **Create summarized report based on WCAG Success Criteria.** While axe-core references the WCAG Success Criteria (SC) in its output, the test itself is conducted based on axe-core's original set of rules. To see how the set of web pages have passed each of the WCAG SC supported by axe-core, axe-scan can provide you with a summarized report grouped by the SC.
 
@@ -182,18 +182,18 @@ To create an output CSV file:
 axe-scan run > axe-results.csv
 ```
 
-Returns an error if `urls.txt` is not found. Optionally designate a custom path for the list of URLs using the `--file` option. Likewise, optionally designate a list of whitelisted alerts using the `--whitelist` flag. The matching alerts will be excluded from the output:
+Returns an error if `urls.txt` is not found. Optionally designate a custom path for the list of URLs using the `--file` option. Likewise, optionally designate an allowlist file path using the `--allowlist` flag. The matching alerts will be excluded from the output:
 
 ```
-axe-scan run --file urls-list.txt --whitelist /path/to/whitelisted-alerts.csv > result-whitelisted.csv
+axe-scan run --file urls-list.txt --allowlist /path/to/allowlisted-alerts.csv > result-allowlisted.csv
 ```
 
-For details on whitelisting, see the [Define whitelist section](#define-whitelist).
+For details on using the allowlist, see the [Define allowlist section](#define-allowlist).
 
 #### Options
 
 - `-F`, `--file <urlsFilePath>`: Designate the file path for the list of URLs on which to conduct the accessibility test.
-- `-W`, `--whitelist <whitelistFilePath>`: Designate the file path for the list of whitelisted accessibility alerts.
+- `-A`, `--allowlist <allowlistFilePath>`: Designate the file path for the allowlist of accessibility alerts.
 
 ### Create a summarized report
 
@@ -209,25 +209,25 @@ You may want to see also the [Testing on websites with basic authentication](#te
 
 - `-F`, `--file <urlsFilePath>`: Designate the file path for the list of URLs on which to conduct the accessibility test.
 - `-P`, `--page`: Create the summary report on per page basis.
-- `-W`, `--whitelist <whitelistFilePath>`: Designate the file path for the list of whitelisted accessibility alerts.
+- `-A`, `--allowlist <allowlistFilePath>`: Designate the file path for the allowlist of accessibility alerts.
 
-### Define whitelist
+### Define allowlist
 
-The results of `axe-scan run` are likely to come with items whose result type is `incomplete`, which refers to HTML elements that require further testing and manual checks. If, after further testing, you decide to regard the item as `passes` (= no accessibility issue found), you can add it to the whitelist.
+The results of `axe-scan run` are likely to come with items whose result type is `incomplete`, which refers to HTML elements that require further testing and manual checks. If, after further testing, you decide to regard the item as `passes` (= no accessibility issue found), you can add it to the allowlist.
 
-The `whitelist.csv` is essentially a subset of `results.csv` created by:
+The `allowlist.csv` is essentially a subset of `results.csv` created by:
 
 ```
 axe-scan run > results.csv
 ```
 
-Filter the rows that you would like to add to the whitelist and save it as another CSV file, e.g., `whitelist.csv`
+Filter the rows that you would like to add to the allowlist and save it as another CSV file, e.g., `allowlist.csv`. Be sure to copy the first row, i.e., the header row, to the allowlist as well.
 
-You can then run subsequent accessibility tests using the `--whitelist <whitelistFilePath>` option to filter out the whitelisted items from the axe-scan outputs:
+You can then run subsequent accessibility tests using the `--allowlist <allowlistFilePath>` option to filter out the items listed in the allowlist from the axe-scan outputs:
 
 ```
-axe-scan run --whitelist whitelist.csv > results-whitelisted.csv
-axe-scan summary -W whitelist.csv > summary.csv
+axe-scan run --allowlist allowlist.csv > results-allowlisted.csv
+axe-scan summary -A allowlist.csv > summary.csv
 ```
 
 ## Configuring axe-scan

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ program
 
 /**
  * Run the accessibility test and returns the results as a standard output.
- * @example run --file path/to/urls-list.txt --whitelist ./whitelisted-alerts.csv
+ * @example run --file path/to/urls-list.txt --allowlist allowlist.csv
  */
 program
   .command('run')
@@ -72,9 +72,13 @@ program
     'Designate the file path for the list of URLs on which to conduct the accessibility test.'
   )
   .option(
-    '-W, --whitelist <whitelistFilePath>',
-    'Designate the file path for the list of whitelisted accessibility alerts.'
+    '-A, --allowlist <allowlistFilePath>',
+    'Designate the file path for the allowlist of accessibility alerts.'
   )
+  .option(
+    '-W, --whitelist <allowlistFilePath>',
+    'Alias of --allowlist. Scheduled to be deprecated on v2.0. Consider using --allowlist option instead.'
+  ) // Scheduled to be deprecated on v2.0
   .action(run);
 
 program
@@ -88,9 +92,13 @@ program
   )
   .option('-P, --page', 'Create the summary report on per page basis.')
   .option(
-    '-W, --whitelist <whitelistFilePath>',
-    'Designate the file path for the list of whitelisted accessibility alerts.'
+    '-A, --allowlist <allowlistFilePath>',
+    'Designate the file path for the allowlist of accessibility alerts.'
   )
+  .option(
+    '-W, --whitelist <allowlistFilePath>',
+    'Alias of --allowlist. Scheduled to be deprecated on v2.0. Consider using --allowlist option instead.'
+  ) // Scheduled to be deprecated on v2.0
   .action(summary);
 
 (async () => {


### PR DESCRIPTION
#35 
This is the first step. `-W | --whitelist` will be kept available as an alias of `-A | --allowlist` during v1.x. `--whitelist` will be deprecated on and after v2.0.