### PR TITLE
Add `--raw` option to `run` command to output raw axe-core results in stringified JSON format (#46)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,6 @@ export type ConfigValue = {
   axeCoreTags: string[]; // See https://www.deque.com/axe/core-documentation/api-documentation/#user-content-axe-core-tags for possible values
   resultTypes: string[]; // Possible values are elements of RESULT_TYPES_FULL_SET
   filePath: string;
-  // encoding: string;
   locale: string;
 };
 export const DEFAULT_LOCALE = 'en';
@@ -30,7 +29,6 @@ export const DEFAULT_CONFIG: ConfigValue = {
   axeCoreTags: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
   resultTypes: ['incomplete', 'violations'],
   filePath: './urls.txt',
-  // encoding: 'utf8',
   locale: `${DEFAULT_LOCALE}`,
 };
 export const RESULT_TYPES_FULL_SET = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,12 +68,16 @@ program
   .command('run')
   .description('Run the accessibility test.')
   .option(
+    '-A, --allowlist <allowlistFilePath>',
+    'Designate the file path for the allowlist of accessibility alerts.'
+  )
+  .option(
     '-F, --file <urlsFilePath>',
     'Designate the file path for the list of URLs on which to conduct the accessibility test.'
   )
   .option(
-    '-A, --allowlist <allowlistFilePath>',
-    'Designate the file path for the allowlist of accessibility alerts.'
+    '-R, --raw',
+    'Output the raw axe-core result in stringified JSON instead of the usual CSV.'
   )
   .action(run);
 


### PR DESCRIPTION
Resolve #46 