### PR TITLE
Add accessibility-alt-text-bot to GitHub workflow

### DIFF
--- a/.github/workflows/a11y_alt_text_bot.yml
+++ b/.github/workflows/a11y_alt_text_bot.yml
@@ -1,0 +1,27 @@
+name: Accessibility-alt-text-bot
+on: 
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  accessibility_alt_text_bot:
+    name: Check alt text is set on issue or pull requests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
+    steps:
+      - name: Get action 'github/accessibility-alt-text-bot'
+        uses: github/accessibility-alt-text-bot@v1.2.0 # Set to latest
+        


### PR DESCRIPTION
See [Make your GitHub projects more accessible with accessibility-alt-text-bot | The GitHub Blog](https://github.blog/2023-06-12-make-your-github-projects-more-accessible-with-accessibility-alt-text-bot/) for more details.