### PR TITLE
🐛 Skip empty url lines

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -56,6 +56,7 @@ export default async function (options: CommandOption): Promise<void> {
   const urls: string[] = fs
     .readFileSync(filePath /*, { encoding: config.encoding }*/)
     .toString()
+    .trim()
     .replace(/\r?\n/g, ',')
     .split(',');
 
@@ -71,7 +72,12 @@ export default async function (options: CommandOption): Promise<void> {
   let outputText: string = raw ? '' : REPORT_HEADER.join();
   const rawAxeResults: RawAxeResults = {};
   for (let i = 0; i < urls.length; i++) {
-    const url: string = urls[i];
+    const url: string = urls[i].trim();
+
+    if (!url) {
+      continue;
+    }
+
     const page: puppeteer.Page = await browser.newPage();
     await page.setBypassCSP(true);
     /* Emulate device: left here as a potential option for the future


### PR DESCRIPTION
My colleague kept getting the `Protocol error (Page.navigate): Cannot navigate to invalid URL` error, even though the URLs in the `urls.txt` file seemed ok.

Turns out it was because her text editor kept adding a trailing newline, breaking the script.
A lot of editors do this, and it's not really clear to the user what is exactly going wrong, so it's best to just filter out any empty line.